### PR TITLE
Fix FloatToInt syscall behavior

### DIFF
--- a/crates/rfvp/src/subsystem/components/syscalls/utils.rs
+++ b/crates/rfvp/src/subsystem/components/syscalls/utils.rs
@@ -28,11 +28,11 @@ pub fn break_point(_game_data: &mut GameData) -> Result<Variant> {
 }
 
 pub fn float_to_int(_game_data: &mut GameData, value: &Variant) -> Result<Variant> {
-    let value = if let Variant::Int(value) = value {
-        *value
+    let value = if let Variant::Float(value) = value {
+        *value as i32
     } else {
-        log::error!("float_to_int: Invalid value type");
-        return Ok(Variant::Nil);
+        log::warn!("float_to_int: Invalid value type");
+        return Ok(Variant::Int(0));
     };
 
     Ok(Variant::Int(value))


### PR DESCRIPTION
The behavior must match reference engine - if value is not Float variant, it should be coerced to Int variant with value of 0, otherwise it is to be interpreted as i32 of itself.

This fixes all HD remasters using FVP engine. See screenshots for behavior before and after using AstralAir FHD as example.

---

**Before**:
<img width="1920" height="1009" alt="rfvp_2026-02-28_21-27-49" src="https://github.com/user-attachments/assets/d421b1a7-a3a0-48d8-9d57-8ba967ca66c9" />
<img width="1920" height="1009" alt="rfvp_2026-02-28_21-31-04" src="https://github.com/user-attachments/assets/14be0e8c-46b2-456c-98de-e7d2474c631a" />


**After**:
<img width="1920" height="1009" alt="rfvp_2026-02-28_21-56-38" src="https://github.com/user-attachments/assets/ca4566cb-22cb-4833-9ab0-d000d3e2e1b5" />
<img width="1920" height="1009" alt="rfvp_2026-02-28_21-56-17" src="https://github.com/user-attachments/assets/211be90f-e67a-4130-8aab-a4cd3b34e3ee" />
